### PR TITLE
Fixed error on consecutive numbering

### DIFF
--- a/lib/rcat/display.rb
+++ b/lib/rcat/display.rb
@@ -6,7 +6,7 @@ module RCat
     end
 
     def render(data)
-      @line_number = 1
+      @line_number ||= 1
 
       lines = data.lines
       loop { render_line(lines) }


### PR DESCRIPTION
Hi,

I just went through your article about rcat. After trying to run your tests I noticed a failing test on multiple input files.

I fixed this by changing 
      @line_number = 1
to
      @line_number ||= 1

Now all tests are passing
